### PR TITLE
Fix backspace crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ class App extends React.Component {
         const r = parseInt(e.target.value, 10);
         // Text inputs can sometimes temporarily be in invalid states.
         // If it's not a valid number, refuse to set it.
-        if (typeof r !== "undefined") {
+        if (!isNaN(r)) {
           this.setState({[state_key]: r});
         }
       };


### PR DESCRIPTION
Fixes #2. If this change is accepted, the user is not allowed to backspace but is allowed to enter an additional digit given the `maxlength` property allows it. For example, the text input for Input size can be changed from the default value 5 to 55. However, for other values, the user has adjust using the slider.